### PR TITLE
Add link.xml to fix crash on iOS

### DIFF
--- a/Assets/Scenes/LoginScene.unity
+++ b/Assets/Scenes/LoginScene.unity
@@ -954,7 +954,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   LoginPanel: {fileID: 590240403}
   ConnectingLabel: {fileID: 446264581}
-  NextScene: 
 --- !u!4 &623190796
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/LoginScene.unity
+++ b/Assets/Scenes/LoginScene.unity
@@ -954,6 +954,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   LoginPanel: {fileID: 590240403}
   ConnectingLabel: {fileID: 446264581}
+  NextScene: MainScene
 --- !u!4 &623190796
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/LoginScene.unity
+++ b/Assets/Scenes/LoginScene.unity
@@ -954,7 +954,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   LoginPanel: {fileID: 590240403}
   ConnectingLabel: {fileID: 446264581}
-  NextScene: MainScene
+  NextScene: 
 --- !u!4 &623190796
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/link.xml
+++ b/Assets/link.xml
@@ -1,0 +1,5 @@
+<linker> 
+<assembly fullname="System.Core"> 
+<type fullname="System.Linq.Expressions.Interpreter.LightLambda" preserve="all" /> 
+</assembly> 
+</linker>


### PR DESCRIPTION
System.Linq.Expressions.Interpreter.LightLambda is needed in link.xml to fix a crash on iOS

Driveby fix - adds 'MainScene' to NextScene property on LoginScene.