### PR TITLE
TTM sequence is done log text wise

### DIFF
--- a/Assets/Scripts/Ffb/Dto/Reports/RightStuffRoll.cs
+++ b/Assets/Scripts/Ffb/Dto/Reports/RightStuffRoll.cs
@@ -1,0 +1,7 @@
+﻿namespace Fumbbl.Ffb.Dto.Reports
+{
+    public class RightStuffRoll : SkillRoll
+    {
+        public RightStuffRoll() : base("rightStuffRoll") { }
+    }
+}

--- a/Assets/Scripts/Ffb/Dto/Reports/RightStuffRoll.cs.meta
+++ b/Assets/Scripts/Ffb/Dto/Reports/RightStuffRoll.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8fc27517e6b5ba840892b9ca83f71389
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Model/RollModifier/PassModifier.cs
+++ b/Assets/Scripts/Model/RollModifier/PassModifier.cs
@@ -6,16 +6,16 @@
         public bool DistanceModifier { get; set; } = false;
         public string Shortcut { get; set; }
 
-        public static PassModifier QuickPass = new PassModifier("Quick Pass", -1) { DistanceModifier = true, Shortcut = "Q"};
-        public static PassModifier ShortPass = new PassModifier("Short Pass", 0) { DistanceModifier = true, Shortcut = "S", SignMode = SignMode.Hidden, ShowModifier = false, ShowName = false };
-        public static PassModifier LongPass = new PassModifier("Long Pass", 1) { DistanceModifier = true, Shortcut = "L"};
-        public static PassModifier LongBomb = new PassModifier("Long Bomb", 2) { DistanceModifier = true, Shortcut = "B"};
-        public static PassModifier Accurate = new PassModifier("Accurate", -1) {};
+        public static PassModifier QuickPass = new PassModifier("Quick Pass", -1) { DistanceModifier = true, Shortcut = "Q" };
+        public static PassModifier ShortPass = new PassModifier("Short Pass", 0) { DistanceModifier = true, Shortcut = "S" };
+        public static PassModifier LongPass = new PassModifier("Long Pass", 1) { DistanceModifier = true, Shortcut = "L" };
+        public static PassModifier LongBomb = new PassModifier("Long Bomb", 2) { DistanceModifier = true, Shortcut = "B" };
+        public static PassModifier Accurate = new PassModifier("Accurate", -1) { };
         public static PassModifier NervesOfSteel = new PassModifier("Nerves of Steel", 0) { SignMode = SignMode.Hidden, ShowModifier = false, ShowName = false };
-        public static PassModifier StrongArm = new PassModifier("Strong Arm", -1) {};
-        public static PassModifier VerySunny = new PassModifier("Very Sunny", 1) {};
+        public static PassModifier StrongArm = new PassModifier("Strong Arm", -1) { };
+        public static PassModifier VerySunny = new PassModifier("Very Sunny", 1) { };
         public static PassModifier Blizzard = new PassModifier("Blizzard", 0) { SignMode = SignMode.Hidden, ShowModifier = false, ShowName = false };
-        public static PassModifier Stunty = new PassModifier("Stunty", 1) {};
+        public static PassModifier Stunty = new PassModifier("Stunty", 1) { };
         public static PassModifier Tacklezone1 = new PassModifier("1 Tacklezone", 1) { ShowModifier = false };
         public static PassModifier Tacklezone2 = new PassModifier("2 Tacklezones", 2) { ShowModifier = false };
         public static PassModifier Tacklezone3 = new PassModifier("3 Tacklezones", 3) { ShowModifier = false };
@@ -35,7 +35,7 @@
         public static PassModifier DisturbingPresence9 = new PassModifier("9 Disturbing Presences", 9) { ShowModifier = false };
         public static PassModifier DisturbingPresence10 = new PassModifier("10 Disturbing Presences", 10) { ShowModifier = false };
         public static PassModifier DisturbingPresence11 = new PassModifier("11 Disturbing Presences", 11) { ShowModifier = false };
-        public static PassModifier ThrowTeamMate = new PassModifier("Throw Team-Mate", 1) {};
-        public static PassModifier GromskullsExplodingRunes = new PassModifier("Gromskull's Exploding Runes", 1) {};
+        public static PassModifier ThrowTeamMate = new PassModifier("Throw Team-Mate", 1) { };
+        public static PassModifier GromskullsExplodingRunes = new PassModifier("Gromskull's Exploding Runes", 1) { };
     }
 }

--- a/Assets/Scripts/UI/LogText/RightStuffRoll.cs
+++ b/Assets/Scripts/UI/LogText/RightStuffRoll.cs
@@ -1,0 +1,53 @@
+﻿using Fumbbl.Model;
+using Fumbbl.Model.Types;
+using Fumbbl.Model.RollModifier;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using UnityEngine;
+
+namespace Fumbbl.UI.LogText
+{
+    public class RightStuffRoll : LogTextGenerator<Ffb.Dto.Reports.RightStuffRoll>
+    {
+        public override IEnumerable<LogRecord> Convert(Ffb.Dto.Reports.RightStuffRoll report)
+        {
+            Player player = FFB.Instance.Model.GetPlayer(report.playerId);
+            string neededRoll = "";
+
+            IEnumerable<RightStuffModifier> rollModifiers = report.rollModifiers?.Select(r => r.As<RightStuffModifier>());
+
+            yield return new LogRecord($"<b>Right Stuff Roll [ {report.roll} ]</b>");
+
+            if (report.successful)
+            {
+                yield return new LogRecord($"{player.FormattedName} lands on {player.Gender.Genetive} feet.", 1);
+                if (!report.reRolled)
+                {
+                    neededRoll = $"Succeeded on a roll of {report.minimumRoll}+";
+                }
+            }
+            else
+            {
+                yield return new LogRecord($"{player.FormattedName} crashes to the ground.", 1);
+                if (!report.reRolled)
+                {
+                    neededRoll = $"Roll a {report.minimumRoll}+ to succeed";
+                }
+            }
+
+            if (!string.IsNullOrEmpty(neededRoll))
+            {
+                neededRoll += $" (AG {Math.Min(6, player.Agility)}";
+                if (rollModifiers != null)
+                {
+                    neededRoll += string.Join("", rollModifiers.Select(m => m.ModifierString));
+                }
+
+                neededRoll += " + Roll > 6).";
+                yield return new LogRecord(neededRoll, 2);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/UI/LogText/RightStuffRoll.cs.meta
+++ b/Assets/Scripts/UI/LogText/RightStuffRoll.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 14f5ea8a8bf1ba04a9c1c4e09847e026
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/LogText/ThrowTeamMateRoll.cs
+++ b/Assets/Scripts/UI/LogText/ThrowTeamMateRoll.cs
@@ -5,8 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-using UnityEngine;
-
 namespace Fumbbl.UI.LogText
 {
     public class ThrowTeamMateRoll : LogTextGenerator<Ffb.Dto.Reports.ThrowTeamMateRoll>
@@ -18,8 +16,9 @@ namespace Fumbbl.UI.LogText
             string neededRoll = "";
 
             // Make the passingDistance the first modifier and the reported ones follow it.
-            IEnumerable<PassModifier> rollModifiers = report.passingDistance.As<PassModifier>().Yield();
-            rollModifiers.Concat(report.rollModifiers?.Select(r => r.As<PassModifier>()));
+            IEnumerable<PassModifier> rollModifiers1 = report.passingDistance.As<PassModifier>().Yield();
+            IEnumerable<PassModifier> rollModifiers2 = report.rollModifiers?.Select(r => r.As<PassModifier>());
+            IEnumerable<PassModifier> rollModifiers = rollModifiers1.Concat(rollModifiers2);
 
             if (!report.reRolled)
             {


### PR DESCRIPTION
Some remarks:

PassModifier.cs: Seems that despite the 0 modifier, Short Passes are reported in the FFBJava log. I adapted this. The rest are minor code styling.

ThrowTeamMateRoll.cs: Comparing the logs showed that the report modifiers were not concatenated to the distance. This is now fixed, though I do not fully examined why the former was not working. Anyway,  the process is now cleaner and easier to debug.