### PR TITLE
Logtext.TurnEnd

### DIFF
--- a/Assets/Scripts/FFB.cs
+++ b/Assets/Scripts/FFB.cs
@@ -325,7 +325,6 @@ namespace Fumbbl
                 FFB.Instance.Model.Half = cmd.game.half;
                 FFB.Instance.Model.TurnHome = cmd.game.turnDataHome.turnNr;
                 FFB.Instance.Model.TurnAway = cmd.game.turnDataAway.turnNr;
-                FFB.Instance.Model.LastTurnMode = cmd.game.lastTurnMode.As<TurnMode>();
                 FFB.Instance.Model.TurnMode = cmd.game.turnMode.As<TurnMode>();
 
                 FFB.Instance.Model.ScoreHome = cmd.game.gameResult.teamResultHome.score;

--- a/Assets/Scripts/FFB.cs
+++ b/Assets/Scripts/FFB.cs
@@ -317,6 +317,8 @@ namespace Fumbbl
                 FFB.Instance.Model.Half = cmd.game.half;
                 FFB.Instance.Model.TurnHome = cmd.game.turnDataHome.turnNr;
                 FFB.Instance.Model.TurnAway = cmd.game.turnDataAway.turnNr;
+                FFB.Instance.Model.LastTurnMode = cmd.game.lastTurnMode.As<TurnMode>();
+                FFB.Instance.Model.TurnMode = cmd.game.turnMode.As<TurnMode>();
 
                 FFB.Instance.Model.ScoreHome = cmd.game.gameResult.teamResultHome.score;
                 FFB.Instance.Model.ScoreAway = cmd.game.gameResult.teamResultAway.score;

--- a/Assets/Scripts/Ffb/Dto/Commands/Game.cs
+++ b/Assets/Scripts/Ffb/Dto/Commands/Game.cs
@@ -19,8 +19,8 @@ namespace Fumbbl.Ffb.Dto.Commands
         public bool timeoutEnforced;
         public bool concessionPossible;
         public bool testing;
-        public string turnMode;
-        public string lastTurnMode;
+        public FFBEnumeration turnMode;
+        public FFBEnumeration lastTurnMode;
         public string defenderId;
         public string defenderAction;
         public int[] passCoordinate;

--- a/Assets/Scripts/Ffb/Dto/ModelChanges/GameSetHomePlaying.cs
+++ b/Assets/Scripts/Ffb/Dto/ModelChanges/GameSetHomePlaying.cs
@@ -1,0 +1,11 @@
+﻿
+namespace Fumbbl.Ffb.Dto.ModelChanges
+{
+    public class GameSetHomePlaying : ModelChange
+    {
+        public bool modelChangeValue;
+        public GameSetHomePlaying() : base("gameSetHomePlaying")
+        {
+        }
+    }
+}

--- a/Assets/Scripts/Ffb/Dto/ModelChanges/GameSetHomePlaying.cs.meta
+++ b/Assets/Scripts/Ffb/Dto/ModelChanges/GameSetHomePlaying.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4aa825c79d822634fa5f388647f6cd9d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Ffb/Dto/ModelChanges/GameSetTurnMode.cs
+++ b/Assets/Scripts/Ffb/Dto/ModelChanges/GameSetTurnMode.cs
@@ -1,0 +1,11 @@
+﻿
+namespace Fumbbl.Ffb.Dto.ModelChanges
+{
+    public class GameSetTurnMode : ModelChange
+    {
+        public FFBEnumeration modelChangeValue;
+        public GameSetTurnMode() : base("gameSetTurnMode")
+        {
+        }
+    }
+}

--- a/Assets/Scripts/Ffb/Dto/ModelChanges/GameSetTurnMode.cs.meta
+++ b/Assets/Scripts/Ffb/Dto/ModelChanges/GameSetTurnMode.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6a3dacc6f32447943b6abecd2c0cacc2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Ffb/Dto/Reports/HeatExhaustionResult.cs
+++ b/Assets/Scripts/Ffb/Dto/Reports/HeatExhaustionResult.cs
@@ -1,0 +1,9 @@
+namespace Fumbbl.Ffb.Dto.Reports
+{
+    public class HeatExhaustionResult
+    {
+        public bool exhausted;
+        public string playerId;
+        public int roll;
+    }
+}

--- a/Assets/Scripts/Ffb/Dto/Reports/HeatExhaustionResult.cs.meta
+++ b/Assets/Scripts/Ffb/Dto/Reports/HeatExhaustionResult.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: edaf2d5c21c382847adb6503e06e2f6e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Ffb/Dto/Reports/KnockoutRecoveryResult.cs
+++ b/Assets/Scripts/Ffb/Dto/Reports/KnockoutRecoveryResult.cs
@@ -1,0 +1,10 @@
+namespace Fumbbl.Ffb.Dto.Reports
+{
+    public class KnockoutRecoveryResult
+    {
+        public int bloodweiserBabes;
+        public string playerId;
+        public bool recovering;
+        public int roll;
+    }
+}

--- a/Assets/Scripts/Ffb/Dto/Reports/KnockoutRecoveryResult.cs.meta
+++ b/Assets/Scripts/Ffb/Dto/Reports/KnockoutRecoveryResult.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e53a4b2bfbe0cde4b979947c5a772ceb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Ffb/Dto/Reports/TurnEnd.cs
+++ b/Assets/Scripts/Ffb/Dto/Reports/TurnEnd.cs
@@ -5,7 +5,7 @@ namespace Fumbbl.Ffb.Dto.Reports
         public TurnEnd() : base("turnEnd") { }
         public string reportId;
         public string playerIdTouchdown;
-        public string[] knockoutRecoveries;
-        public string[] heatExhaustions;
+        public KnockoutRecoveryResult[] knockoutRecoveryArray;
+        public HeatExhaustionResult[] heatExhaustionArray;
     }
 }

--- a/Assets/Scripts/Model/Core.cs
+++ b/Assets/Scripts/Model/Core.cs
@@ -82,6 +82,7 @@ namespace Fumbbl.Model
         public int Half { get; internal set; }
         public int TurnHome { get; internal set; }
         public int TurnAway { get; internal set; }
+        public TurnMode TurnMode { get; set; }
         public int ScoreHome { get; internal set; }
         public int ScoreAway { get; internal set; }
         public Team TeamHome { get; internal set; }
@@ -92,15 +93,14 @@ namespace Fumbbl.Model
 
         public Core()
         {
-            ActingPlayer = new ActingPlayer();
-            Ball = new Ball();
-            BlockDice = new List<View.BlockDie>();
             //ModelChangeFactory = new ModelChangeFactory();
             ModelChangeFactory = new ReflectedFactory<ModelUpdater<Ffb.Dto.ModelChange>, Type>();
+            ActingPlayer = new ActingPlayer();
             Players = new Dictionary<string, Player>();
+            Ball = new Ball();
             PushbackSquares = new Dictionary<int, View.PushbackSquare>();
             TrackNumbers = new Dictionary<int, View.TrackNumber>();
-            TurnMode = TurnMode.StartGame;
+            BlockDice = new List<View.BlockDie>();
         }
 
         public void Clear()
@@ -170,29 +170,5 @@ namespace Fumbbl.Model
             }
             return null;
         }
-
-        private TurnMode lastturnmode;
-        public TurnMode LastTurnMode {
-            get { return lastturnmode; }
-            set {
-                if (value == lastturnmode) return;
-                lastturnmode = value;
-                Debug.Log($"LastTurnMode: {lastturnmode.Name}");
-            }
-        }
-        private TurnMode turnmode;
-        public TurnMode TurnMode {
-            get { return turnmode; }
-            set {
-                if (value == turnmode) return;
-                TurnMode cachedlastturnmode = turnmode;
-                turnmode = value;
-                if (cachedlastturnmode != null && !cachedlastturnmode.StoreLast){
-                    LastTurnMode = cachedlastturnmode;
-                }
-                Debug.Log($"TurnMode: {turnmode.Name}");
-            }
-        }
-
     }
 }

--- a/Assets/Scripts/Model/Core.cs
+++ b/Assets/Scripts/Model/Core.cs
@@ -92,14 +92,15 @@ namespace Fumbbl.Model
 
         public Core()
         {
+            ActingPlayer = new ActingPlayer();
+            Ball = new Ball();
+            BlockDice = new List<View.BlockDie>();
             //ModelChangeFactory = new ModelChangeFactory();
             ModelChangeFactory = new ReflectedFactory<ModelUpdater<Ffb.Dto.ModelChange>, Type>();
-            ActingPlayer = new ActingPlayer();
             Players = new Dictionary<string, Player>();
-            Ball = new Ball();
             PushbackSquares = new Dictionary<int, View.PushbackSquare>();
             TrackNumbers = new Dictionary<int, View.TrackNumber>();
-            BlockDice = new List<View.BlockDie>();
+            TurnMode = TurnMode.StartGame;
         }
 
         public void Clear()
@@ -169,5 +170,29 @@ namespace Fumbbl.Model
             }
             return null;
         }
+
+        private TurnMode lastturnmode;
+        public TurnMode LastTurnMode {
+            get { return lastturnmode; }
+            set {
+                if (value == lastturnmode) return;
+                lastturnmode = value;
+                Debug.Log($"LastTurnMode: {lastturnmode.Name}");
+            }
+        }
+        private TurnMode turnmode;
+        public TurnMode TurnMode {
+            get { return turnmode; }
+            set {
+                if (value == turnmode) return;
+                TurnMode cachedlastturnmode = turnmode;
+                turnmode = value;
+                if (cachedlastturnmode != null && !cachedlastturnmode.StoreLast){
+                    LastTurnMode = cachedlastturnmode;
+                }
+                Debug.Log($"TurnMode: {turnmode.Name}");
+            }
+        }
+
     }
 }

--- a/Assets/Scripts/Model/ModelChange/GameSetHomePlaying.cs
+++ b/Assets/Scripts/Model/ModelChange/GameSetHomePlaying.cs
@@ -1,0 +1,14 @@
+﻿using Fumbbl.Model.Types;
+
+namespace Fumbbl.Model.ModelChange
+{
+    public class GameSetHomePlaying : ModelUpdater<Ffb.Dto.ModelChanges.GameSetHomePlaying>
+    {
+        public GameSetHomePlaying() : base(typeof(Ffb.Dto.ModelChanges.GameSetHomePlaying)) { }
+
+        public override void Apply(Ffb.Dto.ModelChanges.GameSetHomePlaying change)
+        {
+            FFB.Instance.Model.HomePlaying = change.modelChangeValue;
+        }
+    }
+}

--- a/Assets/Scripts/Model/ModelChange/GameSetHomePlaying.cs.meta
+++ b/Assets/Scripts/Model/ModelChange/GameSetHomePlaying.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6970b4a35719e99489dd924e2f869122
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Model/ModelChange/GameSetTurnMode.cs
+++ b/Assets/Scripts/Model/ModelChange/GameSetTurnMode.cs
@@ -1,0 +1,14 @@
+﻿using Fumbbl.Model.Types;
+
+namespace Fumbbl.Model.ModelChange
+{
+    public class GameSetTurnMode : ModelUpdater<Ffb.Dto.ModelChanges.GameSetTurnMode>
+    {
+        public GameSetTurnMode() : base(typeof(Ffb.Dto.ModelChanges.GameSetTurnMode)) { }
+
+        public override void Apply(Ffb.Dto.ModelChanges.GameSetTurnMode change)
+        {
+            FFB.Instance.Model.TurnMode = change.modelChangeValue.As<TurnMode>();
+        }
+    }
+}

--- a/Assets/Scripts/Model/ModelChange/GameSetTurnMode.cs.meta
+++ b/Assets/Scripts/Model/ModelChange/GameSetTurnMode.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9722372fe65e5984e9c3274f16d8848e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Model/Types/Player.cs
+++ b/Assets/Scripts/Model/Types/Player.cs
@@ -67,7 +67,8 @@ namespace Fumbbl.Model.Types
         {
             get
             {
-                string color = IsHome ? "#ff0000" : "#0000ff";
+                var colorsettings = FFB.Instance.Settings.Color;
+                string color = IsHome ? colorsettings.HomeColor : colorsettings.AwayColor;
                 return $"<color={color}>{TextPanelHandler.SanitizeText(Name)}</color>";
             }
         }

--- a/Assets/Scripts/Model/Types/Player.cs
+++ b/Assets/Scripts/Model/Types/Player.cs
@@ -67,7 +67,7 @@ namespace Fumbbl.Model.Types
             get
             {
                 string color = IsHome ? "#ff0000" : "#0000ff";
-                return $"<{color}>{TextPanelHandler.SanitizeText(Name)}</color>";
+                return $"<color={color}>{TextPanelHandler.SanitizeText(Name)}</color>";
             }
         }
 

--- a/Assets/Scripts/Model/Types/Team.cs
+++ b/Assets/Scripts/Model/Types/Team.cs
@@ -13,7 +13,7 @@
             get
             {
                 string color = IsHome ? "#ff0000" : "#0000ff";
-                return $"<{color}>{TextPanelHandler.SanitizeText(Name)}</color>";
+                return $"<color={color}>{TextPanelHandler.SanitizeText(Name)}</color>";
             }
         }
 

--- a/Assets/Scripts/Model/Types/Team.cs
+++ b/Assets/Scripts/Model/Types/Team.cs
@@ -12,7 +12,8 @@
         {
             get
             {
-                string color = IsHome ? "#ff0000" : "#0000ff";
+                var colorsettings = FFB.Instance.Settings.Color;
+                string color = IsHome ? colorsettings.HomeColor : colorsettings.AwayColor;
                 return $"<color={color}>{TextPanelHandler.SanitizeText(Name)}</color>";
             }
         }

--- a/Assets/Scripts/Model/Types/TurnMode.cs
+++ b/Assets/Scripts/Model/Types/TurnMode.cs
@@ -4,26 +4,26 @@
     {
         public TurnMode(string name) : base(name) { }
 
-        public static TurnMode Regular = new TurnMode("regular") { };
-        public static TurnMode Setup = new TurnMode("setup") { };
-        public static TurnMode Kickoff = new TurnMode("kickoff") { };
-        public static TurnMode PerfectDefence = new TurnMode("perfectDefence") { };
-        public static TurnMode QuickSnap = new TurnMode("quickSnap") { };
-        public static TurnMode HighKick = new TurnMode("highKick") { };
-        public static TurnMode StartGame = new TurnMode("startGame") { };
-        public static TurnMode Blitz = new TurnMode("blitz") { };
-        public static TurnMode Touchback = new TurnMode("touchback") { };
-        public static TurnMode Interception = new TurnMode("interception") { };
-        public static TurnMode EndGame = new TurnMode("endGame") { };
-        public static TurnMode KickoffReturn = new TurnMode("kickoffReturn") { };
-        public static TurnMode Wizard = new TurnMode("wizard") { };
-        public static TurnMode PassBlock = new TurnMode("passBlock") { };
-        public static TurnMode DumpOff = new TurnMode("dumpOff") { };
-        public static TurnMode NoPlayersToField = new TurnMode("noPlayersToField") { };
-        public static TurnMode BombHome = new TurnMode("bombHome") { };
-        public static TurnMode BombAway = new TurnMode("bombAway") { };
-        public static TurnMode BombHomeBlitz = new TurnMode("bombHomeBlitz") { };
-        public static TurnMode BombAwayBlitz = new TurnMode("bombAwayBlitz") { };
-        public static TurnMode IllegalSubstitution = new TurnMode("illegalSubstitution") { };
+        public static TurnMode Regular = new TurnMode("regular");
+        public static TurnMode Setup = new TurnMode("setup");
+        public static TurnMode Kickoff = new TurnMode("kickoff");
+        public static TurnMode PerfectDefence = new TurnMode("perfectDefence");
+        public static TurnMode QuickSnap = new TurnMode("quickSnap");
+        public static TurnMode HighKick = new TurnMode("highKick");
+        public static TurnMode StartGame = new TurnMode("startGame");
+        public static TurnMode Blitz = new TurnMode("blitz");
+        public static TurnMode Touchback = new TurnMode("touchback");
+        public static TurnMode Interception = new TurnMode("interception");
+        public static TurnMode EndGame = new TurnMode("endGame");
+        public static TurnMode KickoffReturn = new TurnMode("kickoffReturn");
+        public static TurnMode Wizard = new TurnMode("wizard");
+        public static TurnMode PassBlock = new TurnMode("passBlock");
+        public static TurnMode DumpOff = new TurnMode("dumpOff");
+        public static TurnMode NoPlayersToField = new TurnMode("noPlayersToField");
+        public static TurnMode BombHome = new TurnMode("bombHome");
+        public static TurnMode BombAway = new TurnMode("bombAway");
+        public static TurnMode BombHomeBlitz = new TurnMode("bombHomeBlitz");
+        public static TurnMode BombAwayBlitz = new TurnMode("bombAwayBlitz");
+        public static TurnMode IllegalSubstitution = new TurnMode("illegalSubstitution");
     }
 }

--- a/Assets/Scripts/Model/Types/TurnMode.cs
+++ b/Assets/Scripts/Model/Types/TurnMode.cs
@@ -2,30 +2,28 @@
 {
     public class TurnMode : FfbEnumerationFactory
     {
-        public bool StoreLast;
-
         public TurnMode(string name) : base(name) { }
 
-        public static TurnMode Regular = new TurnMode("regular") { StoreLast = true };
-        public static TurnMode Setup = new TurnMode("setup") { StoreLast = true };
-        public static TurnMode Kickoff = new TurnMode("kickoff") { StoreLast = true };
-        public static TurnMode PerfectDefence = new TurnMode("perfectDefence") { StoreLast = true };
-        public static TurnMode QuickSnap = new TurnMode("quickSnap") { StoreLast = true };
-        public static TurnMode HighKick = new TurnMode("highKick") { StoreLast = true };
-        public static TurnMode StartGame = new TurnMode("startGame") { StoreLast = true };
-        public static TurnMode Blitz = new TurnMode("blitz") { StoreLast = true };
-        public static TurnMode Touchback = new TurnMode("touchback") { StoreLast = true };
-        public static TurnMode Interception = new TurnMode("interception") { StoreLast = true };
-        public static TurnMode EndGame = new TurnMode("endGame") { StoreLast = true };
-        public static TurnMode KickoffReturn = new TurnMode("kickoffReturn") { StoreLast = true };
-        public static TurnMode Wizard = new TurnMode("wizard") { StoreLast = true };
-        public static TurnMode PassBlock = new TurnMode("passBlock") { StoreLast = true };
-        public static TurnMode DumpOff = new TurnMode("dumpOff") { StoreLast = true };
-        public static TurnMode NoPlayersToField = new TurnMode("noPlayersToField") { StoreLast = true };
-        public static TurnMode BombHome = new TurnMode("bombHome") { StoreLast = false };
-        public static TurnMode BombAway = new TurnMode("bombAway") { StoreLast = false };
-        public static TurnMode BombHomeBlitz = new TurnMode("bombHomeBlitz") { StoreLast = false };
-        public static TurnMode BombAwayBlitz = new TurnMode("bombAwayBlitz") { StoreLast = false };
-        public static TurnMode IllegalSubstitution = new TurnMode("illegalSubstitution") { StoreLast = true };
+        public static TurnMode Regular = new TurnMode("regular") { };
+        public static TurnMode Setup = new TurnMode("setup") { };
+        public static TurnMode Kickoff = new TurnMode("kickoff") { };
+        public static TurnMode PerfectDefence = new TurnMode("perfectDefence") { };
+        public static TurnMode QuickSnap = new TurnMode("quickSnap") { };
+        public static TurnMode HighKick = new TurnMode("highKick") { };
+        public static TurnMode StartGame = new TurnMode("startGame") { };
+        public static TurnMode Blitz = new TurnMode("blitz") { };
+        public static TurnMode Touchback = new TurnMode("touchback") { };
+        public static TurnMode Interception = new TurnMode("interception") { };
+        public static TurnMode EndGame = new TurnMode("endGame") { };
+        public static TurnMode KickoffReturn = new TurnMode("kickoffReturn") { };
+        public static TurnMode Wizard = new TurnMode("wizard") { };
+        public static TurnMode PassBlock = new TurnMode("passBlock") { };
+        public static TurnMode DumpOff = new TurnMode("dumpOff") { };
+        public static TurnMode NoPlayersToField = new TurnMode("noPlayersToField") { };
+        public static TurnMode BombHome = new TurnMode("bombHome") { };
+        public static TurnMode BombAway = new TurnMode("bombAway") { };
+        public static TurnMode BombHomeBlitz = new TurnMode("bombHomeBlitz") { };
+        public static TurnMode BombAwayBlitz = new TurnMode("bombAwayBlitz") { };
+        public static TurnMode IllegalSubstitution = new TurnMode("illegalSubstitution") { };
     }
 }

--- a/Assets/Scripts/Model/Types/TurnMode.cs
+++ b/Assets/Scripts/Model/Types/TurnMode.cs
@@ -1,0 +1,31 @@
+﻿namespace Fumbbl.Model.Types
+{
+    public class TurnMode : FfbEnumerationFactory
+    {
+        public bool StoreLast;
+
+        public TurnMode(string name) : base(name) { }
+
+        public static TurnMode Regular = new TurnMode("regular") { StoreLast = true };
+        public static TurnMode Setup = new TurnMode("setup") { StoreLast = true };
+        public static TurnMode Kickoff = new TurnMode("kickoff") { StoreLast = true };
+        public static TurnMode PerfectDefence = new TurnMode("perfectDefence") { StoreLast = true };
+        public static TurnMode QuickSnap = new TurnMode("quickSnap") { StoreLast = true };
+        public static TurnMode HighKick = new TurnMode("highKick") { StoreLast = true };
+        public static TurnMode StartGame = new TurnMode("startGame") { StoreLast = true };
+        public static TurnMode Blitz = new TurnMode("blitz") { StoreLast = true };
+        public static TurnMode Touchback = new TurnMode("touchback") { StoreLast = true };
+        public static TurnMode Interception = new TurnMode("interception") { StoreLast = true };
+        public static TurnMode EndGame = new TurnMode("endGame") { StoreLast = true };
+        public static TurnMode KickoffReturn = new TurnMode("kickoffReturn") { StoreLast = true };
+        public static TurnMode Wizard = new TurnMode("wizard") { StoreLast = true };
+        public static TurnMode PassBlock = new TurnMode("passBlock") { StoreLast = true };
+        public static TurnMode DumpOff = new TurnMode("dumpOff") { StoreLast = true };
+        public static TurnMode NoPlayersToField = new TurnMode("noPlayersToField") { StoreLast = true };
+        public static TurnMode BombHome = new TurnMode("bombHome") { StoreLast = false };
+        public static TurnMode BombAway = new TurnMode("bombAway") { StoreLast = false };
+        public static TurnMode BombHomeBlitz = new TurnMode("bombHomeBlitz") { StoreLast = false };
+        public static TurnMode BombAwayBlitz = new TurnMode("bombAwayBlitz") { StoreLast = false };
+        public static TurnMode IllegalSubstitution = new TurnMode("illegalSubstitution") { StoreLast = true };
+    }
+}

--- a/Assets/Scripts/Model/Types/TurnMode.cs.meta
+++ b/Assets/Scripts/Model/Types/TurnMode.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c8314895de3fda543af513985c9e035d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Settings.cs
+++ b/Assets/Scripts/Settings.cs
@@ -7,11 +7,13 @@ namespace Fumbbl
 {
     public class Settings
     {
+        public ColorSettings Color;
         public GraphicsSettings Graphics;
         public SoundSettings Sound;
 
         public Settings()
         {
+            Color = new ColorSettings();
             Graphics = new GraphicsSettings();
             Sound = new SoundSettings();
         }
@@ -31,6 +33,7 @@ namespace Fumbbl
                 string jsonSettings = File.ReadAllText(path);
 
                 Settings settings = JsonConvert.DeserializeObject<Settings>(jsonSettings);
+                this.Color = settings.Color;
                 this.Graphics = settings.Graphics;
                 this.Sound = settings.Sound;
             }
@@ -39,6 +42,13 @@ namespace Fumbbl
                 Save();
             }
         }
+    }
+
+
+    public class ColorSettings
+    {
+        public string HomeColor = "#FF0000";
+        public string AwayColor = "#0000FF";
     }
 
     public class GraphicsSettings

--- a/Assets/Scripts/UI/LogText/TurnEnd.cs
+++ b/Assets/Scripts/UI/LogText/TurnEnd.cs
@@ -11,6 +11,7 @@ namespace Fumbbl.UI.LogText
     {
         public override IEnumerable<LogRecord> Convert(Ffb.Dto.Reports.TurnEnd report)
         {
+            var colorsettings = FFB.Instance.Settings.Color;
             Player scorer = FFB.Instance.Model.GetPlayer(report.playerIdTouchdown);
             if (scorer != null)
             {
@@ -61,11 +62,11 @@ namespace Fumbbl.UI.LogText
             {
                 if (FFB.Instance.Model.HomePlaying)
                 {
-                    yield return new LogRecord($"<size=16><color=#ff0000>{FFB.Instance.Model.TeamHome.Name} start turn {FFB.Instance.Model.TurnHome}.</color></size>");
+                    yield return new LogRecord($"<size=16><color={colorsettings.HomeColor}>{FFB.Instance.Model.TeamHome.Name} start turn {FFB.Instance.Model.TurnHome}.</color></size>");
                 }
                 else
                 {
-                    yield return new LogRecord($"<size=16><color=#0000ff>{FFB.Instance.Model.TeamAway.Name} start turn {FFB.Instance.Model.TurnAway}.</color></size>");
+                    yield return new LogRecord($"<size=16><color={colorsettings.AwayColor}>{FFB.Instance.Model.TeamAway.Name} start turn {FFB.Instance.Model.TurnAway}.</color></size>");
                 }
             }
         }

--- a/Assets/Scripts/UI/LogText/TurnEnd.cs
+++ b/Assets/Scripts/UI/LogText/TurnEnd.cs
@@ -16,7 +16,58 @@ namespace Fumbbl.UI.LogText
             {
                 yield return new LogRecord($"{scorer.FormattedName} scores a touchdown.", 1);
             }
-            // TODO: unfinished
+            if (0 < report.knockoutRecoveryArray?.Length)
+            {
+                string s = String.Empty;
+                foreach (Fumbbl.Ffb.Dto.Reports.KnockoutRecoveryResult res in report.knockoutRecoveryArray)
+                {
+                    Player player = FFB.Instance.Model.GetPlayer(res.playerId);
+
+                    s = $"<b>Knockout Recovery Roll [ {res.roll} ]</b>";
+                    if (0 < res.bloodweiserBabes)
+                    {
+                        s += $"<b> + {res.bloodweiserBabes} Bloodweiser Babes</b>";
+                    }
+                    yield return new LogRecord(s);
+                    if (res.recovering)
+                    {
+                        yield return new LogRecord($"{player.FormattedName} is regaining consciousness.", 1);
+                    }
+                    else
+                    {
+                        yield return new LogRecord($"{player.FormattedName} stays unconscious.", 1);
+                    }
+                }
+            }
+            if (0 < report.heatExhaustionArray?.Length)
+            {
+                string s = String.Empty;
+                foreach (Fumbbl.Ffb.Dto.Reports.HeatExhaustionResult res in report.heatExhaustionArray)
+                {
+                    Player player = FFB.Instance.Model.GetPlayer(res.playerId);
+
+                    s = $"<b>Heat Exhaustion Roll [ {res.roll} ]</b>";
+                    if (res.exhausted)
+                    {
+                        yield return new LogRecord($"{player.FormattedName} is suffering from heat exhaustion.", 1);
+                    }
+                    else
+                    {
+                        yield return new LogRecord($"{player.FormattedName} is unaffected.", 1);
+                    }
+                }
+            }
+            if (FFB.Instance.Model.TurnMode == TurnMode.Regular)
+            {
+                if (FFB.Instance.Model.HomePlaying)
+                {
+                    yield return new LogRecord($"<size=16><color=#ff0000>{FFB.Instance.Model.TeamHome.Name} start turn {FFB.Instance.Model.TurnHome}.</color></size>");
+                }
+                else
+                {
+                    yield return new LogRecord($"<size=16><color=#0000ff>{FFB.Instance.Model.TeamAway.Name} start turn {FFB.Instance.Model.TurnAway}.</color></size>");
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Some Remarks:

- FFB.cs: initial command sets TurnMode which has now its own factory Type
- Game.cs: turnMode and lastTurnMode changed from string to FFBEnumeration
- GameSetHomePlaying.cs: dependency ModelChange added
- GameSetTurnMode.cs: dependency ModelChange added
- HeatExhaustionResult.cs: nested JSON object of TurnEnd report
- KnockoutRecoveryResult.cs: nested JSON object of TurnEnd report
- TurnEnd.cs: DTO fields fixed and now those are arrays of the above two DTO container types
- Core.cs L94--103: TurnMode is set by the constructor. Fields sorted alphabetically.
- Core.cs L173+: TurnMode and LastTurnMode properties. Setters were converted from the Java client except they are not yet notify. Instead a debug log was made for now.
- Team.cs: fixed color tag in rich text format
- TurnMode.cs: new converted model type
- TurnEnd.cs: well, this was the goal
