### PR TITLE
Make client more robust against missing images

### DIFF
--- a/Assets/Scripts/Api/FumbblApi.cs
+++ b/Assets/Scripts/Api/FumbblApi.cs
@@ -101,8 +101,16 @@ public class FumbblApi
         catch (WebException ex)
         {
             HttpWebResponse resp = ex.Response as HttpWebResponse;
-            Debug.LogWarning($"Failed to download ({(int)resp.StatusCode}, {resp.StatusCode}): \"{url}\"");
-            return null;
+            if (resp == null)
+            {
+                Debug.LogWarning($"Failed to download: \"{url}\" Due to exception: {ex}");
+                return null;
+            }
+            else
+            {
+                Debug.LogWarning($"Failed to download ({(int)resp.StatusCode}, {resp.StatusCode}): \"{url}\"");
+                return null;
+            }
         }
         Sprite s = Sprite.Create(img, new Rect(0, 0, img.width, img.height), new Vector2(0.5f, 0.5f), 1f, 0, SpriteMeshType.FullRect);
         s.name = url;

--- a/Assets/Scripts/Api/FumbblApi.cs
+++ b/Assets/Scripts/Api/FumbblApi.cs
@@ -103,14 +103,22 @@ public class FumbblApi
             HttpWebResponse resp = ex.Response as HttpWebResponse;
             if (resp == null)
             {
-                Debug.LogWarning($"Failed to download: \"{url}\" Due to exception: {ex}");
-                return null;
+                Debug.LogError($"Failed to download: \"{url}\" Due to exception: {ex}");
             }
             else
             {
-                Debug.LogWarning($"Failed to download ({(int)resp.StatusCode}, {resp.StatusCode}): \"{url}\"");
-                return null;
+                if (resp.StatusCode == HttpStatusCode.NotFound)
+                {
+                    // 404 (NotFound) is not that serious, some images are naturally missing.
+                    Debug.LogWarning($"Failed to download ({(int)resp.StatusCode}, {resp.StatusCode}): \"{url}\"");
+                    return null;
+                }
+                else
+                {
+                    Debug.LogError($"Failed to download ({(int)resp.StatusCode}, {resp.StatusCode}): \"{url}\"");
+                }
             }
+            return null;
         }
         Sprite s = Sprite.Create(img, new Rect(0, 0, img.width, img.height), new Vector2(0.5f, 0.5f), 1f, 0, SpriteMeshType.FullRect);
         s.name = url;

--- a/Assets/Scripts/Api/FumbblApi.cs
+++ b/Assets/Scripts/Api/FumbblApi.cs
@@ -100,7 +100,9 @@ public class FumbblApi
         }
         catch (WebException ex)
         {
-            Debug.LogError("Failed to download: " + url + " Due to exception: " + ex);
+            HttpWebResponse resp = ex.Response as HttpWebResponse;
+            Debug.LogWarning($"Failed to download ({(int)resp.StatusCode}, {resp.StatusCode}): \"{url}\"");
+            return null;
         }
         Sprite s = Sprite.Create(img, new Rect(0, 0, img.width, img.height), new Vector2(0.5f, 0.5f), 1f, 0, SpriteMeshType.FullRect);
         s.name = url;

--- a/Assets/Scripts/Lib/PlayerIcon.cs
+++ b/Assets/Scripts/Lib/PlayerIcon.cs
@@ -20,10 +20,10 @@ namespace Fumbbl.Lib
                 PlayerIcon.LoadSprite(p.Position.IconURL, target);
                 return obj;
             }
-            catch(Exception ex)
+            catch(MissingPlayerIconException ex1)
             {
                 GameObject.Destroy(obj);
-                Debug.LogError("Exception loading player sprite, falling back to abstract icons: " + ex);
+                Debug.LogWarning($"Exception loading player sprite, falling back to abstract icons: {ex1}");
                 return GeneratePlayerIconAbstract(p, fallbackPrefab);
             }
         }
@@ -98,6 +98,9 @@ namespace Fumbbl.Lib
         private static Sprite LoadIconSpriteSheet(string iconURL)
         {
             Sprite s = FFB.Instance.SpriteCache.Get(iconURL);
+            if (s == null) {
+                 throw new MissingPlayerIconException($"Missing Player icon: \"{iconURL}\"");
+            };
             var iconSize = s.texture.width / 4;
             int numTextures = s.texture.height / iconSize;
 
@@ -140,4 +143,19 @@ namespace Fumbbl.Lib
             return Sprite.Create(dest, new Rect(0, 0, dest.width, dest.height), new Vector2(0.5f, 0.5f), 1f, 0, SpriteMeshType.FullRect);
         }
     }
+
+    // https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/exceptions/creating-and-throwing-exceptions#defining-exception-classes
+    [Serializable()]
+    public class MissingPlayerIconException : System.Exception
+    {
+        public MissingPlayerIconException() : base() { }
+        public MissingPlayerIconException(string message) : base(message) { }
+        public MissingPlayerIconException(string message, System.Exception inner) : base(message, inner) { }
+
+        // A constructor is needed for serialization when an
+        // exception propagates from a remoting server to the client.
+        protected MissingPlayerIconException(System.Runtime.Serialization.SerializationInfo info,
+            System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+    }
+
 }

--- a/Assets/Scripts/Lib/PlayerIcon.cs
+++ b/Assets/Scripts/Lib/PlayerIcon.cs
@@ -14,18 +14,15 @@ namespace Fumbbl.Lib
         public static GameObject GeneratePlayerIcon(Player p, GameObject iconPrefab, GameObject fallbackPrefab)
         {
             GameObject obj = PlayerIcon.CreatePlayerIcon(p, iconPrefab);
-            try
-            {
-                var target = obj.transform.GetChild(0).gameObject;
-                PlayerIcon.LoadSprite(p.Position.IconURL, target);
-                return obj;
-            }
-            catch(MissingPlayerIconException ex1)
+            GameObject target = obj.transform.GetChild(0).gameObject;
+            bool success = PlayerIcon.LoadSprite(p.Position.IconURL, target);
+            if (!success)
             {
                 GameObject.Destroy(obj);
-                Debug.LogWarning($"Exception loading player sprite, falling back to abstract icons: {ex1}");
-                return GeneratePlayerIconAbstract(p, fallbackPrefab);
+                Debug.LogWarning($"Unable to load player icons for PlayerId {p.Id}, falling back to abstract");
+                obj = GeneratePlayerIconAbstract(p, fallbackPrefab);
             }
+            return obj;
         }
 
         public static GameObject GeneratePlayerIconAbstract(Player p, GameObject prefab)
@@ -43,9 +40,10 @@ namespace Fumbbl.Lib
             return obj;
         }
 
-        public static void LoadSprite(string iconURL, GameObject target)
+        public static bool LoadSprite(string iconURL, GameObject target)
         {
             Sprite resized = LoadIconSpriteSheet(iconURL);
+            if (resized == null) { return false; };
             FFB.Instance.ExecuteOnMainThread(() =>
             {
                 var renderer = target.GetComponent<SpriteRenderer>();
@@ -53,6 +51,7 @@ namespace Fumbbl.Lib
                 rect.sizeDelta = new Vector2(192, 192);
                 renderer.sprite = resized;
             });
+            return true;
         }
 
         private static void CopyTexture(Sprite s, int srcIconSize, Texture2D dest, int destMip, int y, int x)
@@ -98,9 +97,7 @@ namespace Fumbbl.Lib
         private static Sprite LoadIconSpriteSheet(string iconURL)
         {
             Sprite s = FFB.Instance.SpriteCache.Get(iconURL);
-            if (s == null) {
-                 throw new MissingPlayerIconException($"Missing Player icon: \"{iconURL}\"");
-            };
+            if (s == null) { return s; };
             var iconSize = s.texture.width / 4;
             int numTextures = s.texture.height / iconSize;
 
@@ -143,19 +140,4 @@ namespace Fumbbl.Lib
             return Sprite.Create(dest, new Rect(0, 0, dest.width, dest.height), new Vector2(0.5f, 0.5f), 1f, 0, SpriteMeshType.FullRect);
         }
     }
-
-    // https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/exceptions/creating-and-throwing-exceptions#defining-exception-classes
-    [Serializable()]
-    public class MissingPlayerIconException : System.Exception
-    {
-        public MissingPlayerIconException() : base() { }
-        public MissingPlayerIconException(string message) : base(message) { }
-        public MissingPlayerIconException(string message, System.Exception inner) : base(message, inner) { }
-
-        // A constructor is needed for serialization when an
-        // exception propagates from a remoting server to the client.
-        protected MissingPlayerIconException(System.Runtime.Serialization.SerializationInfo info,
-            System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
-    }
-
 }


### PR DESCRIPTION
- 404 which is a natural cause of missing images is handled more softly than other exceptions (DebugWarning instead of DebugError).
- FumbblApi.GetSpriteAsync() task do not throw exception, it returns null instead which gets to the sprite cache and is handled specially in the appropriate modules.